### PR TITLE
Multiple find words with individual highlighting color

### DIFF
--- a/src/TextAreaWithFindHighlighting/Output/Output.interface.ts
+++ b/src/TextAreaWithFindHighlighting/Output/Output.interface.ts
@@ -1,7 +1,7 @@
 export type Props = {
   inputValue: string;
   selectionPositions: number[];
-  wordToHighlight: string;
+  wordsToHighlight: string[];
   isCaseSensitive: boolean;
   textSelectionStyling: { color: string; backgroundColor: string };
   wordFindHighlightingStyling: { color: string };

--- a/src/TextAreaWithFindHighlighting/Output/Output.interface.ts
+++ b/src/TextAreaWithFindHighlighting/Output/Output.interface.ts
@@ -4,7 +4,7 @@ export type Props = {
   wordsToHighlight: string[];
   isCaseSensitive: boolean;
   textSelectionStyling: { color: string; backgroundColor: string };
-  wordFindHighlightingStyling: { color: string };
+  wordFindHighlightingStyling: { color: string[] };
   useRegularExpression: boolean;
   scrollTop: number;
 };

--- a/src/TextAreaWithFindHighlighting/Output/Output.tsx
+++ b/src/TextAreaWithFindHighlighting/Output/Output.tsx
@@ -30,10 +30,21 @@ function regExpEscapeSpecialChars(strToEscape: string) {
     .join("");
 }
 
+const wordToHighlightRegex = (
+  wordToHighlight: string,
+  useRegularExpression: boolean,
+  isCaseSensitive: boolean
+) => {
+  if (!useRegularExpression) {
+    wordToHighlight = `${regExpEscapeSpecialChars(wordToHighlight)}`;
+  }
+  return new RegExp(`${wordToHighlight}`, `g${isCaseSensitive ? "" : "i"}`);
+};
+
 function Output({
   inputValue,
   selectionPositions,
-  wordToHighlight,
+  wordsToHighlight,
   isCaseSensitive,
   textSelectionStyling,
   wordFindHighlightingStyling,
@@ -69,26 +80,29 @@ function Output({
     }
   }
 
-  const wordToHighlightRegex = () => {
-    if (!useRegularExpression) {
-      wordToHighlight = `${regExpEscapeSpecialChars(wordToHighlight)}`;
-    }
-    return new RegExp(`${wordToHighlight}`, `g${isCaseSensitive ? "" : "i"}`);
-  };
-
-  try {
-    const matches = [...inputValue.matchAll(wordToHighlightRegex())];
-    if (matches.length) {
-      for (const match of matches) {
-        tagData.push(
-          ["open", "highlight", match.index!],
-          ["close", "highlight", match.index! + match[0].length]
-        );
+  for (const wordToHighlight of wordsToHighlight) {
+    try {
+      const matches = [
+        ...inputValue.matchAll(
+          wordToHighlightRegex(
+            wordToHighlight,
+            useRegularExpression,
+            isCaseSensitive
+          )
+        ),
+      ];
+      if (matches.length) {
+        for (const match of matches) {
+          tagData.push(
+            ["open", "highlight", match.index!],
+            ["close", "highlight", match.index! + match[0].length]
+          );
+        }
       }
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      regexErrorMessage = error.message;
+    } catch (error) {
+      if (error instanceof Error) {
+        regexErrorMessage = error.message;
+      }
     }
   }
 

--- a/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.interface.ts
+++ b/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.interface.ts
@@ -1,5 +1,5 @@
 export type Props = {
-  wordToHighlight: string;
+  wordsToHighlight: string[];
   isCaseSensitive: boolean;
   textAreaFormDataName: string;
   useRegularExpression: boolean;

--- a/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.tsx
+++ b/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.tsx
@@ -20,7 +20,7 @@ const configureStyles = {
     backgroundColor: "cornflowerblue",
   },
   wordFindHighlighting: {
-    color: "red",
+    color: ["red"],
   },
 };
 

--- a/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.tsx
+++ b/src/TextAreaWithFindHighlighting/TextAreaWithFindHighlighting.tsx
@@ -25,7 +25,7 @@ const configureStyles = {
 };
 
 export default function TextAreaWithFindHighlighting({
-  wordToHighlight = "test",
+  wordsToHighlight = ["test"],
   isCaseSensitive = false,
   textAreaFormDataName = "findWordTextArea",
   useRegularExpression = true,
@@ -49,7 +49,7 @@ export default function TextAreaWithFindHighlighting({
       <Output
         inputValue={inputValue}
         selectionPositions={selectionPositions}
-        wordToHighlight={wordToHighlight}
+        wordsToHighlight={wordsToHighlight}
         isCaseSensitive={isCaseSensitive}
         textSelectionStyling={configureStyles.textSelection}
         wordFindHighlightingStyling={configureStyles.wordFindHighlighting}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import "./index.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <TextAreaWithFindHighlighting
-      wordToHighlight="test"
+      wordsToHighlight={["test"]}
       isCaseSensitive={false}
       textAreaFormDataName="findWordTextArea"
       useRegularExpression={false}


### PR DESCRIPTION
Allows user to define multiple words to be found. Each separate word can receive its own highlighting color based on index number.
For example:
"words to highlight" = ["word1", "word2", "word3"]
"highlighting colors" = ["red", "blue", "green"]
If the "highlighting colors" array is shorter than the "words to highlight" array, the last color is used for the extra words.

A maximum of nine "highlighting colors" can be defined. Any more throws an error and message. 